### PR TITLE
Wording correction

### DIFF
--- a/exec.c
+++ b/exec.c
@@ -37,7 +37,7 @@ int main( void )
   if( child_pid == 0 )
   {
     execl("/bin/ls", "ls", NULL );
-    exit( EXIT_SUCCESS );
+    exit( EXIT_FAILURE );
   }
 
   waitpid( child_pid, &status, 0 );


### PR DESCRIPTION
The only way the child process would continue to line 40 is if exec failed.